### PR TITLE
fix a bug in error handling on parseYAML

### DIFF
--- a/internal/config/reader.go
+++ b/internal/config/reader.go
@@ -50,7 +50,9 @@ func parseYAML(path string, cfg *Config) (err error) {
 	}
 
 	defer func() {
-		err = file.Close()
+		if e := file.Close(); err == nil {
+			err = e
+		}
 	}()
 
 	decoder := yaml.NewDecoder(file)


### PR DESCRIPTION
The error is always equal to the output of the file.Close() and other errors destroy